### PR TITLE
Add custom renderer plugability

### DIFF
--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -716,8 +716,13 @@ jQuery.extend({
             var infofiltervals = new Array()
             $.each(data.records, function(index, value) {
                 // write them out to the results div
-                $('#facetview_results').append( buildrecord(index) )
-                $('#facetview_results tr:last-child').linkify()
+            	 if (options.renderer) {
+            		 $('#facetview_results').append("<tr><td></td></tr>");
+            		 options.renderer(value, $('#facetview_results tr:last-child td'));
+            	 } else {
+            		 $('#facetview_results').append( buildrecord(index) )
+            		 $('#facetview_results tr:last-child').linkify()
+            	 }
             });
             if ( options.result_box_colours.length > 0 ) {
                 jQuery('.result_box').each(function () {


### PR DESCRIPTION
I've added a new option 'renderer' to the facetview code, if present this overrides the result presentation configured elsewhere apart from the wrapping table which is generated as usual. It causes each hit to be rendered in its own table row with a single td, and passes the jQuery wrapped TD and the object representing the search hit (the underlying data and not the actual hit object) to the function passed in as 'renderer', i.e. you can do:

``` javascript
$('#facetText').facetview({
                search_url : '/api/texts-es?',
                search_index : 'elasticsearch',
                facets : [ {
                    'field' : 'author.name',
                    'display' : 'author'
                }, {
                    'field' : 'year',
                    'display' : 'year'
                } ],
                renderer : function(hit, parent) {
                    parent.append("<div>Title : " + hit.title + "</div>");
                    if (hit.textus && hit.textus.textId) {
                        parent.append("<a class='btn' href='#/text/"+hit.textus.textId+"/0'>Read</a>");
                    }
                }
            });
```
