### PR TITLE
Numeric fields from query response are never displayed

### DIFF
--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -743,7 +743,7 @@ This can define or reference a function that will be executed any time new searc
                             thevalue.push(res[row][parts[counter]]);
                         }
                     }
-                    if (thevalue && thevalue.length) {
+                    if (thevalue && thevalue.toString().length) {
                         display[lineitem][object]['pre']
                             ? line += display[lineitem][object]['pre'] : false;
                         if ( typeof(thevalue) == 'object' ) {


### PR DESCRIPTION
A numeric field value will be omitted from the result
because its length is being tested. I convert to string 
first then check length, allowing numeric fields to 
populate in the result table.
