### PR TITLE
Add support for facet filters

### DIFF
--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -1023,8 +1023,14 @@ Updates the URL string with the current query when the user changes the
                 delete fobj['display'];
                 delete fobj['facet_filter'];
                 var facet = {'terms': fobj};
-                if (facet_filter) {
-                    facet['facet_filter'] = facet_filter;
+                if (facet_filter || qs['filter']) {
+                    facet['facet_filter'] = {'and': []};
+                    if (facet_filter) {
+                        facet['facet_filter']['and'].push(facet_filter);
+                    }
+                    if (qs['filter']) {
+                        facet['facet_filter']['and'].push(qs['filter']);
+                    }
                 }
                 var parts = fobj['field'].split('.');
                 qs['facets'][fobj['field']] = facet;


### PR DESCRIPTION
This patch allows facet filters to be used in facets, by adding a `facet_filter` object to an entry in the `facets` array. This is slightly different to how facet filters are defined in raw elasticsearch json, but it preserves backward-compatibility.

Example:

```
$('#facet-view').facetview({
  ...
  facets: [
    {
      'field': 'document',
      'facet_filter': {
        'and': [
          {'not': {'exists': {'field': 'error.exception'}}},
          {'not': {'term': {'duplicate': true}}}
        ]
      },
      'display': 'Documents'
    }
  ],
  ...
});
```
