### PR TITLE
add _id to resultobj

### DIFF
--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -740,6 +740,14 @@ search box - the end user will not know they are happening.
                     resultobj["records"].push(dataobj.hits.hits[item]._source);
                 }
             }
+
+            // add _id if available
+            for (var i = 0; i < resultobj["records"].length; i++) {
+                if ("_id" in dataobj.hits.hits[i]) {
+                   resultobj["records"][i]["_id"] = dataobj.hits.hits[i]["_id"];
+                }
+            }
+			
             resultobj["start"] = "";
             resultobj["found"] = dataobj.hits.total;
             for (var item in dataobj.facets) {


### PR DESCRIPTION
I came across the problem that I need the documentId _id in the resultobj to do some Javascript hide()/show() stuff. This PR contains my solution to add it always (first steps with facetview & second steps with Elasticsearch, so feel free to reject it :-)
